### PR TITLE
Sign and improve trauma language

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ We, the undersigned, have become aware that, for some time, Jon Pretty has abuse
 
 We state this based on multiple, independent, well-substantiated reports showing a systematic pattern of behavior over an extended period.
 
-Mr. Pretty’s behavior is unacceptable. It is morally repugnant on its face. It directly damages the women involved, sometimes causing lasting trauma. It also indirectly damages the Scala community by creating a more toxic environment, especially for women and newcomers.
+Mr. Pretty’s behavior is unacceptable. It is morally repugnant on its face. It directly damages the women involved causing lasting trauma. It also indirectly damages the Scala community by creating a more toxic environment, especially for women and newcomers.
 
 We demand that Mr. Pretty cease using technical gatherings, within the Scala community or elsewhere, to prey on women. We request that any organization in which Mr. Pretty serves in a leadership or advisory capacity immediately cut ties with him. We call upon organizations and conference organizers to strengthen their codes of conduct to explicitly forbid such behavior.
 

--- a/index.md
+++ b/index.md
@@ -64,6 +64,7 @@ Signed:
 * Danny McClanahan
 * Dario Abdulrehman
 * Dave Pereira-Gurnell
+* David Barri
 * David Gregory
 * Davis Zanot
 * Dean Wampler


### PR DESCRIPTION
I have read and understood the [open letter of support](https://scala-open-letter.github.io) and wish to add my signature.

Also from the comments of the `Don't minimise trauma` commit:

    Saying that sexual assault "sometimes" causes trauma is pretty offensive
    to those of us who *have* experienced sexual assault. The traumas may
    not always be noticable, even to victims, but they're always there.
    
    The word "sometimes" also puts an additional burden on victims because
    when people think that trauma is just an occasional possibility, there
    are many people who them assume that the victim doesn't have trauma,
    usually for completely superficial reasons like "oh they seemed fine to
    me when we chatted in that PR". It then becomes an additional, very
    difficult burden for a victim to need to summon the courage and strength
    to bring up and justify their trauma in certain situations.
    
    We have much greater understanding now of PTSD and CPTSD. Let's
    demonstrate that here and reduce the burden upon victims.
