### PR TITLE
Signature withdrawal

### DIFF
--- a/index.md
+++ b/index.md
@@ -285,7 +285,6 @@ Additional support:
 * Peter Hilton
 * Peter László
 * Phil Curzon
-* Pierangelo Cecchetto
 * Pierre Dal-Pra
 * Pieter Van Geel
 * Piyush Purang


### PR DESCRIPTION
I signed this letter because it was about having a safe community for women, and because I trusted many of the signatories. I acted impulsively and I feel really bad for this. I apologise for the suffering this has caused.
This is a hard lesson for me, and I thank Jon for that