### PR TITLE
introduce links

### DIFF
--- a/index.md
+++ b/index.md
@@ -360,3 +360,8 @@ Please read the following statements by people who were targeted:
 And consider signing the letter:
 
 * [Instructions for signing](https://github.com/scala-open-letter/scala-open-letter.github.io)
+
+In the interest of full transparency and the fundamental principle of due process, the following links contain Jon Pretty's statements regarding the topic:
+
+* Legal developments: https://pretty.direct/statement
+* Cancellation impact: https://pretty.direct/impact


### PR DESCRIPTION
Given that the letter is still an important reference for people to judge Jon Pretty's character and that he has published statements that challenge the contents of the letter, including a legal decision, introducing links to his publications seems a reasonable step.